### PR TITLE
feat: handle new project errors

### DIFF
--- a/frontend/components/NewProjectForm.jsx
+++ b/frontend/components/NewProjectForm.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
+
+export default function NewProjectForm({ user }) {
+  const supabase = useSupabaseClient();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+
+    if (!user) {
+      setError('You must be logged in to create a project.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const { error: supabaseError } = await supabase
+        .from('projects')
+        .insert({ name, description, user_id: user.id });
+
+      if (supabaseError) {
+        setError(supabaseError.message);
+      } else {
+        setName('');
+        setDescription('');
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      {error && <p className="error">{error}</p>}
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Project name"
+        />
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? 'Creating...' : 'Create Project'}
+        </button>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add new project form component with local error state
- wrap supabase calls and show error messages above the form
- disable submit button while requests are pending

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68945ebf3a1c83289bebf0032e1d0337